### PR TITLE
Dependency error in aem-maven-plugin when running maven 3.9+

### DIFF
--- a/src/main/java/com/unic/maven/plugins/aem/mojos/Start.java
+++ b/src/main/java/com/unic/maven/plugins/aem/mojos/Start.java
@@ -15,6 +15,7 @@ package com.unic.maven.plugins.aem.mojos;
 import com.unic.maven.plugins.aem.util.AwaitableProcess.ExecutionResult;
 import com.unic.maven.plugins.aem.util.Expectation;
 import com.unic.maven.plugins.aem.util.FileUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -36,8 +37,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.addAll;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.*;
-import static org.codehaus.plexus.util.StringUtils.isEmpty;
-import static org.codehaus.plexus.util.StringUtils.join;
 
 /**
  * Starts a local AEM instance using a quickstart jar. The quickstart jar must have been provided before hand. Supports setting arbitrary VM parameters
@@ -230,14 +229,14 @@ public class Start extends AwaitInitialization {
                 "-nofork",
                 "-nobrowser",
                 "-verbose",
-                "-r", join(runModes.iterator(), ","),
+                "-r", StringUtils.join(runModes.iterator(), ","),
                 "-port", Integer.toString(getHttpPort())));
         if (isUseControlPort()) {
             commands.add("-use-control-port");
         }
 
         // Servlet context path - by default, AEM runs at the root context.
-        if (!isEmpty(getContextPath())) {
+        if (StringUtils.isNotBlank(getContextPath())) {
             commands.add("-contextpath");
             commands.add(getContextPath());
         }

--- a/src/main/java/com/unic/maven/plugins/aem/util/ExceptionUtil.java
+++ b/src/main/java/com/unic/maven/plugins/aem/util/ExceptionUtil.java
@@ -12,7 +12,7 @@
  */
 package com.unic.maven.plugins.aem.util;
 
-import org.codehaus.plexus.util.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/src/main/java/com/unic/maven/plugins/aem/util/FileUtil.java
+++ b/src/main/java/com/unic/maven/plugins/aem/util/FileUtil.java
@@ -12,12 +12,11 @@
  */
 package com.unic.maven.plugins.aem.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-
-import static org.codehaus.plexus.util.StringUtils.join;
 
 public class FileUtil {
 
@@ -36,7 +35,7 @@ public class FileUtil {
         }
         if (jarFiles.length > 1) {
             throw new MojoExecutionException("Unable to determine the jar file, more than one jar file " +
-                    "was found in the AEM directory " + directory + ": " + join(jarFiles, ", ") + ".");
+                    "was found in the AEM directory " + directory + ": " + StringUtils.join(jarFiles, ", ") + ".");
         }
         return jarFiles[0].getName();
     }

--- a/src/main/java/com/unic/maven/plugins/aem/util/HttpExpectation.java
+++ b/src/main/java/com/unic/maven/plugins/aem/util/HttpExpectation.java
@@ -12,6 +12,7 @@
  */
 package com.unic.maven.plugins.aem.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import unirest.HttpRequest;
 import unirest.HttpResponse;
@@ -21,7 +22,6 @@ import unirest.UnirestException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static org.codehaus.plexus.util.StringUtils.isEmpty;
 
 /**
  * Used to check for responses from HTTP endpoints in a given time.
@@ -72,7 +72,7 @@ public class HttpExpectation extends Expectation<Object> {
     protected Outcome fulfill() {
         HttpRequest<?> request = method == HttpMethod.GET ? Unirest.get(this.url.toExternalForm()) : Unirest.post(this.url.toExternalForm());
         try {
-            if (!isEmpty(this.user)) {
+            if (StringUtils.isNotBlank(this.user)) {
                 request = request.basicAuth(this.user, this.password);
             }
             HttpResponse<String> response = request.asString();


### PR DESCRIPTION
Remove org.codehaus.plexus.util dependencies and replace with StringUtils and Stream-API.

**Reason:**
Maven 3.9.0 removed dependency backward compatibility to plexus-utils (see maven-3.9.0/release-notes)

Possible workaround for 2.0.16 is to define:

```
<groupId>com.unic.maven.plugins</groupId>
                    <artifactId>aem-maven-plugin</artifactId>
                    <version>2.0.16</version>
                    <dependencies>
                        <dependency>
                            <groupId>org.codehaus.plexus</groupId>
                            <artifactId>plexus-utils</artifactId>
                            <version>3.5.1</version>
                        </dependency>
                    </dependencies>
</plugin>
```